### PR TITLE
Fix install issues with dependencies

### DIFF
--- a/install_jupyter.sh
+++ b/install_jupyter.sh
@@ -12,6 +12,7 @@ pip install jupyter
 
 #------------------------------------------------------
 apt-get -y install libncurses5-dev
+apt-get -y install python-dev
 #------------------------------------------------------
 
 pip install readline

--- a/install_stack.sh
+++ b/install_stack.sh
@@ -9,7 +9,7 @@ if ! [ $(id -u) = 0 ]; then
 fi
 
 pip install numpy
-pip install matplotlib
+pip --no-cache-dir install matplotlib
 pip install sympy
 pip install cython
 pip install pandas


### PR DESCRIPTION
Getting "python.h no such file or directory" when running install_jupyter.sh. Adding python-dev as a dependency fixes the issue.