### PR TITLE
fix prep.sh

### DIFF
--- a/prep.sh
+++ b/prep.sh
@@ -27,8 +27,8 @@ apt -y install libzmq3-dev
 
 # dependencies for python-opencv-headless
 #------------------------------------------------------
-apt -y install libjasper libjasper-dev
-apt -y install libjpeg-dev libtiff5-dev libpng12-dev
+apt -y install libjasper-dev
+apt -y install libjpeg-dev libtiff5-dev libpng-dev
 apt -y install libilmbase12
 apt -y install libopenexr22
 apt -y install libgstreamer1.0-0


### PR DESCRIPTION
1. Removed: libjasper
 - Correct packagename is 'libjasper1'. (libjasper'1')
 - libjasper-dev makes libjasper1 installed by its dependencies.

2. Changed: libpng-dev (v1.6) instead of libpng12-dev (v1.2)
 - Avoid the conflicts of dependencies for other packages. (ex. libgtk-3-dev libgtk2.0-dev ...)

o Test environment:
 - Raspberry Pi 3B
 - 2018-06-27-raspbian-stretch-lite.img

o Test
1. Initial settings for RPi :
 - Burn img to SD
 - Password / Hostname / Wifi 
 - Update Packages(apt update && apt upgrade) 
 - Reboot

2. Increase Swapsize
```
 # /etc/dphys-swapfile ::: CONF_SWAPSIZE : 100 => 2048
sudo sed -i -e 's/CONF_SWAPSIZE=100/CONF_SWAPSIZE=2048/' /etc/dphys-swapfile
sudo /etc/init.d/dphys-swapfile stop
sudo /etc/init.d/dphys-swapfile st
```

3. Clone git repo
```
sudo apt install -y git
# git clone https://github.com/kleinee/jns
git clone https://github.com/mt08xx/jns -b develop
cd jns
```

4. Exec scripts
```
sudo ./prep.sh
./inst_stack.sh
./conf_jupyter.sh
```

5. Start jupyter at boot w/ Systemd
```
cat << 'EOF' > /home/pi/jupyter_start.sh && chmod a+x /home/pi/jupyter_start.sh
#!/bin/bash
. /home/pi/.venv/jns/bin/activate
jupyter lab
#jupyter notebook
EOF

cat << 'EOF' | sudo tee /etc/systemd/system/jupyter.service
[Unit]
Description=Jupyter

[Service]
Type=simple
ExecStart=/home/pi/jupyter_start.sh
User=pi
Group=pi
WorkingDirectory=/home/pi/notebooks
Restart=always
RestartSec=10

[Install]
WantedBy=multi-user.target
EOF
```

6. Start jupyter 
```
sudo systemctl daemon-reload
sudo systemctl start jupyter
sudo systemctl enable jupyter
```