### PR TITLE
fix: inst_opencv.sh

### DIFF
--- a/scripts/inst_opencv.sh
+++ b/scripts/inst_opencv.sh
@@ -12,7 +12,7 @@ if ! [ $(id -u) = 0 ]; then
 fi
 
 #------------------------------------------------------
-apt install -y libjasper libjasper-dev
+apt install -y libjasper1 libjasper-dev
 apt install -y libjpeg-dev libtiff5-dev libpng12-dev
 apt install -y libilmbase12
 apt install -y libopenexr22


### PR DESCRIPTION
Fix: 'libjasper' => 'libjasper1'
apt-install fails because package name was wrong
then 'import cv2' fails without it finally.